### PR TITLE
Localization reworked

### DIFF
--- a/privacyIDEAADFSProvider/Adapter.cs
+++ b/privacyIDEAADFSProvider/Adapter.cs
@@ -34,6 +34,7 @@ namespace privacyIDEAADFSProvider
             //get { return new <instance of IAuthenticationAdapterMetadata derived class>; }
             get {
                 AdapterMetadata meta = new AdapterMetadata();
+                meta.AdapterMetadataInit(uidefinition);
                 meta.adapterversion = version;
                 return meta;
             }

--- a/privacyIDEAADFSProvider/AdapterMetadata.cs
+++ b/privacyIDEAADFSProvider/AdapterMetadata.cs
@@ -7,6 +7,14 @@ namespace privacyIDEAADFSProvider
     class AdapterMetadata : IAuthenticationAdapterMetadata
     {
         public string adapterversion { get; set; }
+
+        public ADFSinterface[] inter;
+
+        public void AdapterMetadataInit(ADFSinterface[] adfsinter)
+        {
+            this.inter = adfsinter;
+        }
+
         //Returns the name of the provider that will be shown in the AD FS management UI (not visible to end users)
         public string AdminName
         {
@@ -28,18 +36,20 @@ namespace privacyIDEAADFSProvider
         {
             get
             {
-                return new[] { 
-                    new CultureInfo("en-us").LCID,
-                    new CultureInfo("de-de").LCID,
-                    new CultureInfo("es-ES").LCID,
-                    new CultureInfo("en-GB").LCID,
-                    new CultureInfo("fr-FR").LCID,
-                    new CultureInfo("uk-UA").LCID,
-                    new CultureInfo("uk").LCID,
-                    new CultureInfo("ru").LCID,
-                    new CultureInfo("be").LCID,
-                    new CultureInfo("be-BY").LCID
-                    };
+                List<int> LCIDS = new List<int>();
+                bool HasDefault = false;
+                if (inter != null)
+                {
+                    foreach (ADFSinterface adfsui in inter)
+                    {
+                        LCIDS.Add(adfsui.LCID);
+                        if (adfsui.LCID == 1033) HasDefault = true;
+                    }
+                } 
+                //Fallback and fixup
+                if ((LCIDS.Count == 0) | (!HasDefault)) 
+                    LCIDS.Add(1033);
+                return LCIDS.ToArray();
             }
         }
 
@@ -51,16 +61,19 @@ namespace privacyIDEAADFSProvider
             get
             {
                 Dictionary<int, string> _friendlyNames = new Dictionary<int, string>();
-                _friendlyNames.Add(new CultureInfo("en-us").LCID, "privacyIDEA ADFS authentication provider");
-                _friendlyNames.Add(new CultureInfo("en-GB").LCID, "privacyIDEA ADFS authentication provider");
-                _friendlyNames.Add(new CultureInfo("de-de").LCID, "privacyIDEA ADFS Authentikationsprovider");
-                _friendlyNames.Add(new CultureInfo("es-ES").LCID, "privacyIDEA ADFS authentication provider");
-                _friendlyNames.Add(new CultureInfo("fr-FR").LCID, "privacyIDEA ADFS authentication provider");
-                _friendlyNames.Add(new CultureInfo("uk-UA").LCID, "privacyIDEA ADFS authentication provider");
-                _friendlyNames.Add(new CultureInfo("uk").LCID, "privacyIDEA ADFS authentication provider");
-                _friendlyNames.Add(new CultureInfo("ru").LCID, "privacyIDEA ADFS authentication provider");
-                _friendlyNames.Add(new CultureInfo("be").LCID, "privacyIDEA ADFS authentication provider");
-                _friendlyNames.Add(new CultureInfo("be-BY").LCID, "privacyIDEA ADFS authentication provider");
+                bool HasDefault = false;
+                if (inter != null)
+                {
+                    foreach (ADFSinterface adfsui in inter)
+                    {
+                        _friendlyNames.Add(adfsui.LCID, adfsui.friendlyname);
+                        if (adfsui.LCID == 1033) HasDefault = true;
+                    }
+                }
+                
+                if ((_friendlyNames.Count == 0)|(!HasDefault)) 
+                    _friendlyNames.Add(1033, "privacyIDEA ADFS authentication provider");
+                
                 return _friendlyNames;
             }
         }
@@ -73,16 +86,17 @@ namespace privacyIDEAADFSProvider
             get
             {
                 Dictionary<int, string> _descriptions = new Dictionary<int, string>();
-                _descriptions.Add(new CultureInfo("en-us").LCID, "privacyIDEA ADFS provider to access the api");
-                _descriptions.Add(new CultureInfo("en-GB").LCID, "privacyIDEA ADFS provider to access the api");
-                _descriptions.Add(new CultureInfo("fr-FR").LCID, "privacyIDEA ADFS Provider zur Bedienung der API.");
-                _descriptions.Add(new CultureInfo("es-ES").LCID, "privacyIDEA ADFS provider to access the api");
-                _descriptions.Add(new CultureInfo("de-de").LCID, "privacyIDEA ADFS Provider zur Bedienung der API.");
-                _descriptions.Add(new CultureInfo("uk-UA").LCID, "privacyIDEA ADFS provider to access the api");
-                _descriptions.Add(new CultureInfo("uk").LCID, "privacyIDEA ADFS provider to access the api");
-                _descriptions.Add(new CultureInfo("ru").LCID, "privacyIDEA ADFS provider to access the api");
-                _descriptions.Add(new CultureInfo("be").LCID, "privacyIDEA ADFS provider to access the api");
-                _descriptions.Add(new CultureInfo("be-BY").LCID, "privacyIDEA ADFS provider to access the api");
+                bool HasDefault = false;
+                if (inter != null)
+                {
+                    foreach (ADFSinterface adfsui in inter)
+                    {
+                        _descriptions.Add(adfsui.LCID, adfsui.description);
+                        if (adfsui.LCID == 1033) HasDefault = true;
+                    }
+                }
+                if ((_descriptions.Count == 0)|(!HasDefault))
+                    _descriptions.Add(1033, "privacyIDEA ADFS provider to access the api");
                 return _descriptions;
             }
         }

--- a/privacyIDEAADFSProvider/AdapterPresentationForm.cs
+++ b/privacyIDEAADFSProvider/AdapterPresentationForm.cs
@@ -22,7 +22,8 @@ namespace privacyIDEAADFSProvider
             
             // check the localization with the lcid
             string errormessage = "Login failed! Please try again!";
-            string welcomemassage = "Please provide the one-time-password:";
+            string welcomemessage = "Please provide the one-time-password:";
+            string otptext = "OTP Token";
             string submittext = "Submit";
             string htmlTemplate = Resources.AuthPage; // return normal page
 
@@ -34,10 +35,11 @@ namespace privacyIDEAADFSProvider
                     Debug.WriteLine("ID3A_ADFSadapter: Detected language LCID:"+ lcid);
 #endif
 
-                    if ((int)adfsui.LICD == (int)lcid)
+                    if ((int)adfsui.LCID == (int)lcid)
                     {
                         if (!string.IsNullOrEmpty(adfsui.errormessage)) errormessage = adfsui.errormessage;
-                        if (!string.IsNullOrEmpty(adfsui.welcomemessage)) welcomemassage = adfsui.welcomemessage;
+                        if (!string.IsNullOrEmpty(adfsui.welcomemessage)) welcomemessage = adfsui.welcomemessage;
+                        if (!string.IsNullOrEmpty(adfsui.otptext)) otptext = adfsui.otptext;
                         if (!string.IsNullOrEmpty(adfsui.submittext)) submittext = adfsui.submittext;
                         break;
                     }
@@ -47,14 +49,16 @@ namespace privacyIDEAADFSProvider
             if (error)
             {
                 htmlTemplate = htmlTemplate.Replace("#ERROR#", errormessage);
-                htmlTemplate = htmlTemplate.Replace("#MESSAGE#", welcomemassage);
+                htmlTemplate = htmlTemplate.Replace("#MESSAGE#", welcomemessage);
+                htmlTemplate = htmlTemplate.Replace("#OTPTEXT#", otptext);
                 htmlTemplate = htmlTemplate.Replace("#SUBMIT#", submittext);
             }
             // show the normal logon message
             else
             {
-                htmlTemplate = htmlTemplate.Replace("#MESSAGE#", welcomemassage);
+                htmlTemplate = htmlTemplate.Replace("#MESSAGE#", welcomemessage);
                 htmlTemplate = htmlTemplate.Replace("#ERROR#", "");
+                htmlTemplate = htmlTemplate.Replace("#OTPTEXT#", otptext);
                 htmlTemplate = htmlTemplate.Replace("#SUBMIT#", submittext);
             }
             return htmlTemplate;
@@ -74,9 +78,9 @@ namespace privacyIDEAADFSProvider
             {
                 foreach (ADFSinterface adfsui in inter)
                 {
-                    if ((int)adfsui.LICD == (int)lcid)
+                    if ((int)adfsui.LCID == (int)lcid)
                     {
-                        return adfsui.titel;
+                        return adfsui.title;
                     }
                     // fallback to EN-US if nothing is defined
                     else

--- a/privacyIDEAADFSProvider/AuthError.html
+++ b/privacyIDEAADFSProvider/AuthError.html
@@ -11,7 +11,7 @@
 
         <p id="pageIntroductionText" style="color:red"> Wrong One-Time-Password. Please try again!</p>
         <label for="otpvalue" class="block">One-Time-Password</label>
-        <input id="otpvalue" name="otpvalue" type="text" value="" class="text" placeholder="OTP Password" size="30" />
+        <input id="otpvalue" name="otpvalue" type="text" value="" class="text" placeholder="#OTPTEXT#" size="30" />
         <div id="submissionArea" class="submitMargin">
             <input id="submitButton" type="submit" name="Submit" value="#SUBMIT#" />
         </div>

--- a/privacyIDEAADFSProvider/AuthPage.html
+++ b/privacyIDEAADFSProvider/AuthPage.html
@@ -6,7 +6,7 @@
         <!-- End inputs are required by the presentation framework. -->
         <p id="pageIntroductionText" style="color:red">#ERROR#</p>
         <label for="otpvalue" class="block">#MESSAGE#</label>
-        <input id="otpvalue" name="otpvalue" type="password" value="" class="text" placeholder="OTP Token" size="35" />
+        <input id="otpvalue" name="otpvalue" type="password" value="" class="text" placeholder="#OTPTEXT#" size="35" />
         <div id="submissionArea" class="submitMargin">
             <input id="submitButton" type="submit" name="Submit" value="#SUBMIT#" />
         </div>

--- a/privacyIDEAADFSProvider/config.cs
+++ b/privacyIDEAADFSProvider/config.cs
@@ -142,9 +142,12 @@ namespace privacyIDEAADFSProvider
 
         private string errormessageField;
         private string welcomemessageField;
+        private string otptextField;
         private string submittextField;
-        private int lICDField;
-        private string titelField;
+        private string friendlynameField;
+        private string descriptionField;
+        private int LCIDField;
+        private string titleField;
 
         /// <remarks/>
         [System.Xml.Serialization.XmlElementAttribute(Form = System.Xml.Schema.XmlSchemaForm.Unqualified)]
@@ -174,6 +177,21 @@ namespace privacyIDEAADFSProvider
             }
         }
 
+
+        [System.Xml.Serialization.XmlElementAttribute(Form = System.Xml.Schema.XmlSchemaForm.Unqualified)]
+        public string otptext
+        {
+            get
+            {
+                return this.otptextField;
+            }
+            set
+            {
+                this.otptextField = value;
+            }
+        }
+
+
         [System.Xml.Serialization.XmlElementAttribute(Form = System.Xml.Schema.XmlSchemaForm.Unqualified)]
         public string submittext
         {
@@ -187,33 +205,58 @@ namespace privacyIDEAADFSProvider
             }
         }
 
-        /// <remarks/>
 
-        /// <remarks/>
         [System.Xml.Serialization.XmlElementAttribute(Form = System.Xml.Schema.XmlSchemaForm.Unqualified)]
-        public string titel
+        public string friendlyname
         {
             get
             {
-                return this.titelField;
+                return this.friendlynameField;
             }
             set
             {
-                this.titelField = value;
+                this.friendlynameField = value;
+            }
+        }
+
+        [System.Xml.Serialization.XmlElementAttribute(Form = System.Xml.Schema.XmlSchemaForm.Unqualified)]
+        public string description
+        {
+            get
+            {
+                return this.descriptionField;
+            }
+            set
+            {
+                this.descriptionField = value;
+            }
+        }
+
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute(Form = System.Xml.Schema.XmlSchemaForm.Unqualified)]
+        public string title
+        {
+            get
+            {
+                return this.titleField;
+            }
+            set
+            {
+                this.titleField = value;
             }
         }
 
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        public int LICD
+        public int LCID
         {
             get
             {
-                return this.lICDField;
+                return this.LCIDField;
             }
             set
             {
-                this.lICDField = value;
+                this.LCIDField = value;
             }
         }
     }

--- a/privacyIDEAADFSProvider/config.xml
+++ b/privacyIDEAADFSProvider/config.xml
@@ -20,75 +20,97 @@
   
   <!-- 
         For localization, please use this section (FR and SP are translated by google ;-) ) 
-        If you want to support a other language plase us the 1033 LICD entry - this is the fall back.
+        If you want to support a other language plase us the 1033 LCID entry - this is the fall back.
   -->
 
-  <interface LICD="1033"> <!--EN-US-->
+  <interface LCID="1033"> <!--EN-US-->
     <errormessage>Login failed! Please try again!</errormessage>
     <welcomemessage>Please provide the one-time-password:</welcomemessage>
+    <otptext>OTP Token</otptext>
     <submittext>Submit</submittext>
-    <titel>privacyIDEA OTP Adapter - EN</titel>
-  </interface>
-  <interface LICD="2057"> <!--EN-GB-->
-    <errormessage>Login failed! Please try again!</errormessage>
-    <welcomemessage>Please provide the one-time-password:</welcomemessage>
-    <submittext>Submit</submittext>
-    <titel>privacyIDEA OTP Adapter - EN</titel>
-  </interface>
-  <interface LICD="1031"> <!-- DE-DE -->
-    <errormessage>Login fehlgeschlagen. Bitte versuchen Sie es erneut!</errormessage>
-    <welcomemessage>Bitte geben Sie ihren PIN und OTP Token ein:</welcomemessage>
-    <submittext>Submit</submittext>
-    <titel>privacyIDEA OTP Adapter - DE</titel>
-  </interface>
-  <interface LICD="3082"> <!-- SP-SP (int.) -->
-    <errormessage>Inicio de sesión fallido. Por favor intente de nuevo!</errormessage>
-    <welcomemessage>Ingrese su PIN y token OTP:</welcomemessage>
-    <submittext>Submit</submittext>
-    <titel>privacyIDEA OTP Adapter - ES</titel>
-  </interface>
-  <interface LICD="1036"> <!-- FR-FR -->
-    <errormessage>La connexion a échoué. Veuillez réessayer!</errormessage>
-    <welcomemessage>Veuillez entrer votre code PIN et votre jeton OTP:</welcomemessage>
-    <submittext>Submit</submittext>
-    <titel>privacyIDEA OTP Adapter - FR</titel>
-  </interface>
-  <interface LICD="1058"> <!-- uk-UA -->
-    <errormessage>Щось не вийшло. Спробуй знову!</errormessage>
-    <welcomemessage>Вітаю, друже! Введи одноразовий пароль:</welcomemessage>
-    <submittext>Підтвердити</submittext> 
-   <titel>privacyIDEA OTP Adapter - UA</titel>
-  </interface>
-  <interface LICD="34"> <!-- uk -->
-    <errormessage>Щось не вийшло. Спробуй знову!</errormessage>
-    <welcomemessage>Вітаю, друже! Введи одноразовий пароль:</welcomemessage>
-    <submittext>Підтвердити</submittext>
-    <titel>privacyIDEA OTP Adapter - UA</titel>
-  </interface>
-  <interface LICD="1049"> <!-- ru-RU -->
-    <errormessage>Ошибка входа. Попробуй снова!</errormessage>
-    <welcomemessage>Введи одноразовый пароль:</welcomemessage>
-    <submittext>Подтвердить</submittext>
-    <titel>privacyIDEA OTP Adapter - RU</titel>
-  </interface>
-  <interface LICD="25"> <!-- ru -->
-    <errormessage>Ошибка входа. Попробуй снова!</errormessage>
-    <welcomemessage>Введи одноразовый пароль:</welcomemessage>
-    <submittext>Подтвердить</submittext>
-    <titel>privacyIDEA OTP Adapter - RU</titel>
-  </interface>
-  <interface LICD="1059"> <!-- be-BY -->
-    <errormessage>Памылка ўваходу. Паспрабуй зноў!</errormessage>
-    <welcomemessage>Віншую, сябар! Увядзі аднаразовы пароль:</welcomemessage>
-    <submittext>Пацвердзіць</submittext>
-    <titel>privacyIDEA OTP Adapter - BE</titel>
-  </interface>
-  <interface LICD="35"> <!-- be -->
-    <errormessage>Памылка ўваходу. Паспрабуй зноў!</errormessage>
-    <welcomemessage>Віншую, сябар! Увядзі аднаразовы пароль:</welcomemessage>
-    <submittext>Пацвердзіць</submittext>
-    <titel>privacyIDEA OTP Adapter - BE</titel>
+    <friendlyname>privacyIDEA ADFS authentication provider</friendlyname>
+    <description>privacyIDEA ADFS provider to access the api</description>
+    <title>privacyIDEA OTP Adapter - EN</title>
   </interface>
 
+  <interface LCID="2057"> <!--EN-GB-->
+    <errormessage>Login failed! Please try again!</errormessage>
+    <welcomemessage>Please provide the one-time-password:</welcomemessage>
+    <otptext>OTP Token</otptext>
+    <submittext>Submit</submittext>
+    <friendlyname>privacyIDEA ADFS authentication provider</friendlyname>
+    <description>privacyIDEA ADFS provider to access the api</description>
+    <title>privacyIDEA OTP Adapter - EN</title>
+  </interface>
+
+  <interface LCID="1031"> <!-- DE-DE -->
+    <errormessage>Login fehlgeschlagen. Bitte versuchen Sie es erneut!</errormessage>
+    <welcomemessage>Bitte geben Sie ihren PIN und OTP Token ein:</welcomemessage>
+    <otptext>OTP Token</otptext>
+    <submittext>Submit</submittext>
+    <friendlyname>privacyIDEA ADFS Authentikationsprovider</friendlyname>
+    <description>privacyIDEA ADFS Provider zur Bedienung der API.</description>
+    <title>privacyIDEA OTP Adapter - DE</title>
+  </interface>
+
+  <interface LCID="3082"> <!-- SP-SP (int.) -->
+    <errormessage>Inicio de sesión fallido. Por favor intente de nuevo!</errormessage>
+    <welcomemessage>Ingrese su PIN y token OTP:</welcomemessage>
+    <otptext>OTP Token</otptext>
+    <submittext>Submit</submittext>
+    <friendlyname>privacyIDEA ADFS authentication provider</friendlyname>
+    <description>privacyIDEA ADFS provider to access the api</description>
+    <title>privacyIDEA OTP Adapter - ES</title>
+  </interface>
+
+  <interface LCID="1036"> <!-- FR-FR -->
+    <errormessage>La connexion a échoué. Veuillez réessayer!</errormessage>
+    <welcomemessage>Veuillez entrer votre code PIN et votre jeton OTP:</welcomemessage>
+    <otptext>OTP Token</otptext>
+    <submittext>Submit</submittext>
+    <friendlyname>privacyIDEA ADFS authentication provider</friendlyname>
+    <description>privacyIDEA ADFS provider to access the api</description>
+    <title>privacyIDEA OTP Adapter - FR</title>
+  </interface>
+
+  <interface LCID="1058"> <!-- uk-UA -->
+    <errormessage>Щось не вийшло. Спробуй знову!</errormessage>
+    <welcomemessage>Вітаю, друже! Введи одноразовий пароль:</welcomemessage>
+    <otptext>Одноразовий токен</otptext>
+    <submittext>Підтвердити</submittext> 
+    <friendlyname>privacyIDEA ADFS authentication provider</friendlyname>
+    <description>privacyIDEA ADFS provider to access the api</description>
+   <title>privacyIDEA OTP Adapter - UA</title>
+  </interface>
+
+  <interface LCID="34"> <!-- uk-UA -->
+    <errormessage>Щось не вийшло. Спробуй знову!</errormessage>
+    <welcomemessage>Вітаю, друже! Введи одноразовий пароль:</welcomemessage>
+    <otptext>Одноразовий токен</otptext>
+    <submittext>Підтвердити</submittext> 
+    <friendlyname>privacyIDEA ADFS authentication provider</friendlyname>
+    <description>privacyIDEA ADFS provider to access the api</description>
+   <title>privacyIDEA OTP Adapter - UA</title>
+  </interface>
+
+  <interface LCID="1049"> <!-- ru-RU -->
+    <errormessage>Ошибка входа. Попробуй снова!</errormessage>
+    <welcomemessage>Введи одноразовый пароль:</welcomemessage>
+    <otptext>Одноразовый токен</otptext>
+    <submittext>Подтвердить</submittext>
+    <friendlyname>privacyIDEA ADFS authentication provider</friendlyname>
+    <description>privacyIDEA ADFS provider to access the api</description>
+    <title>privacyIDEA OTP Adapter - RU</title>
+  </interface>
+
+  <interface LCID="25"> <!-- ru-RU -->
+    <errormessage>Ошибка входа. Попробуй снова!</errormessage>
+    <welcomemessage>Введи одноразовый пароль:</welcomemessage>
+    <otptext>Одноразовый токен</otptext>
+    <submittext>Подтвердить</submittext>
+    <friendlyname>privacyIDEA ADFS authentication provider</friendlyname>
+    <description>privacyIDEA ADFS provider to access the api</description>
+    <title>privacyIDEA OTP Adapter - RU</title>
+  </interface>
 
 </server>

--- a/privacyIDEAADFSProvider/config.xsd
+++ b/privacyIDEAADFSProvider/config.xsd
@@ -13,9 +13,12 @@
             <xs:sequence>
               <xs:element name="errormessage" type="xs:string" minOccurs="0" msdata:Ordinal="0" />
               <xs:element name="welcomemessage" type="xs:string" minOccurs="0" msdata:Ordinal="1" />
-              <xs:element name="submittext" type="xs:string" minOccurs="0" msdata:Ordinal="2" />
+              <xs:element name="otptext" type="xs:string" minOccurs="0" msdata:Ordinal="2" />
+              <xs:element name="submittext" type="xs:string" minOccurs="0" msdata:Ordinal="3" />
+              <xs:element name="friendlyname" type="xs:string" minOccurs="0" msdata:Ordinal="4" />
+              <xs:element name="description" type="xs:string" minOccurs="0" msdata:Ordinal="5" />
             </xs:sequence>
-            <xs:attribute name="LICD" type="xs:string" />
+            <xs:attribute name="LCID" type="xs:string" />
           </xs:complexType>
         </xs:element>
       </xs:sequence>


### PR DESCRIPTION
Reworked some metadata code - all localizations are now configured in config.xml and can be added/removed without recompiling the code.
Tested on live AD FS system.
Removed Belarus localization as i couldn't make it work in any tested browser.   
Should merge to 1.3.7 branch without problems.
Localization now includes almost everything on auth page.
Changed some variable names - sorry, it was very hard to distinguish between licd and lcid.
--
Best,
Sergei
 